### PR TITLE
Fix "invalid URL" while trying to download from Libgen.lc  due to relative links are returned from the server.

### DIFF
--- a/LibgenDesktop/Resources/Mirrors/libgen_lc_scimag.xslt
+++ b/LibgenDesktop/Resources/Mirrors/libgen_lc_scimag.xslt
@@ -2,7 +2,7 @@
 <xsl:transform version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:template match="/">
     <xsl:for-each select="(//a[contains(@href, '/scimag/get.php')])[1]">
-      <xsl:value-of select="@href" />
+       <xsl:text>http://libgen.lc</xsl:text><xsl:value-of select="@href" />
     </xsl:for-each>
   </xsl:template>
 </xsl:transform>


### PR DESCRIPTION
This fixes the following problem:

```
[11:46:48 PM] Added to the download queue.
[11:46:48 PM] Started.
[11:46:48 PM] Downloading page: http://libgen.lc/scimag/ads.php?doi=10.1093/ajcn/65.3.737
[11:46:48 PM] Request:
GET http://libgen.lc/scimag/ads.php?doi=10.1093/ajcn/65.3.737
User-Agent: LibgenDesktop/1.4.1
[11:46:49 PM] Server response:
200 OK
Connection: keep-alive
Vary: Accept-Encoding, Accept-Encoding
Date: Tue, 24 Aug 2021 20:46:48 GMT
Server: nginx
Content-Length: 3273
Content-Type: text/html
[11:46:49 PM] Transformation libgen_lc_scimag returned an invalid URL.

```