### PR TITLE
Change mirror request URLs from HTTP to HTTPS

### DIFF
--- a/LibgenDesktop/Resources/Mirrors/mirrors.config
+++ b/LibgenDesktop/Resources/Mirrors/mirrors.config
@@ -1,12 +1,12 @@
 ﻿{
     "gen.lib.rus.ec":
     {
-        "NonFictionDownloadUrl": "http://93.174.95.29/main/{thousand-bucket}/{md5:l}/",
-        "NonFictionCoverUrl": "http://gen.lib.rus.ec/covers/{cover-url}",
-        "NonFictionSynchronizationUrl": "http://gen.lib.rus.ec/json.php",
-        "FictionDownloadUrl": "http://93.174.95.29/fiction/{thousand-bucket}/{md5:l}.{ext}/",
-        "FictionCoverUrl": "http://gen.lib.rus.ec/fictioncovers/{thousand-bucket}/{md5:l}.jpg",
-        "DatabaseDumpPageUrl": "http://gen.lib.rus.ec/dbdumps/",
+        "NonFictionDownloadUrl": "https://93.174.95.29/main/{thousand-bucket}/{md5:l}/",
+        "NonFictionCoverUrl": "https://gen.lib.rus.ec/covers/{cover-url}",
+        "NonFictionSynchronizationUrl": "https://gen.lib.rus.ec/json.php",
+        "FictionDownloadUrl": "https://93.174.95.29/fiction/{thousand-bucket}/{md5:l}.{ext}/",
+        "FictionCoverUrl": "https://gen.lib.rus.ec/fictioncovers/{thousand-bucket}/{md5:l}.jpg",
+        "DatabaseDumpPageUrl": "https://gen.lib.rus.ec/dbdumps/",
         "DatabaseDumpPageTransformation": "genlibrusec_dbdumps",
         "DatabaseDumpManualDownload":
         {
@@ -18,22 +18,22 @@
     },
     "libgen.lc":
     {
-        "NonFictionDownloadUrl": "http://libgen.lc/ads.php?md5={md5}",
+        "NonFictionDownloadUrl": "https://libgen.lc/ads.php?md5={md5}",
         "NonFictionDownloadTransformations": "libgen_lc_nonfiction",
-        "NonFictionCoverUrl": "http://libgen.lc/covers/{cover-url}",
-        "FictionDownloadUrl": "http://libgen.lc/foreignfiction/ads.php?md5={md5}",
+        "NonFictionCoverUrl": "https://libgen.lc/covers/{cover-url}",
+        "FictionDownloadUrl": "https://libgen.lc/foreignfiction/ads.php?md5={md5}",
         "FictionDownloadTransformations": "libgen_lc_fiction",
-        "FictionCoverUrl": "http://libgen.lc/fictioncovers/{thousand-bucket}/{md5}.jpg",
-        "SciMagDownloadUrl": "http://libgen.lc/scimag/ads.php?doi={doi}",
+        "FictionCoverUrl": "https://libgen.lc/fictioncovers/{thousand-bucket}/{md5}.jpg",
+        "SciMagDownloadUrl": "https://libgen.lc/scimag/ads.php?doi={doi}",
         "SciMagDownloadTransformations": "libgen_lc_scimag",
         "RestartSessionOnTimeout": true
     },
     "booklid.org":
     {
-        "NonFictionDownloadUrl": "http://m.booklid.org/s/?q={md5}&e=1",
+        "NonFictionDownloadUrl": "https://m.booklid.org/s/?q={md5}&e=1",
         "NonFictionDownloadTransformations": "booklid_org_step1,booklid_org_step2",
-        "NonFictionCoverUrl": "http://i.booklid.org/covers/{cover-url}",
-        "FictionDownloadUrl": "http://m.booklid.org/s/?q={md5}&e=1",
+        "NonFictionCoverUrl": "https://i.booklid.org/covers/{cover-url}",
+        "FictionDownloadUrl": "https://m.booklid.org/s/?q={md5}&e=1",
         "FictionDownloadTransformations": "booklid_org_step1,booklid_org_step2",
         "RestartSessionOnTimeout": false
     },
@@ -53,8 +53,8 @@
     },
     "GenoType (TOR)":
     {
-        "NonFictionDownloadUrl": "http://genotypeinczgrxr.onion/LG/{thousand-index}/{md5:l}",
-        "FictionDownloadUrl": "http://genotypeinczgrxr.onion/FF/{thousand-index}/{md5:l}.{ext}",
+        "NonFictionDownloadUrl": "https://genotypeinczgrxr.onion/LG/{thousand-index}/{md5:l}",
+        "FictionDownloadUrl": "https://genotypeinczgrxr.onion/FF/{thousand-index}/{md5:l}.{ext}",
         "RestartSessionOnTimeout": false
     },
     "sci-hub.se":


### PR DESCRIPTION
Change mirror request URLs to HTTPS to prevent MITM spiers, and even potential malicious actors performing MITM substitution attacks from performing such attacks. In 2022, this is a bare-minimum change; HTTP without SSL has been insecure and bad practice for over a decade.