### PR TITLE
Grouping of (non-fiction) books by identifier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,8 @@
-﻿[*.cs]
+﻿[*]
+indent_style = space
+indent_size = 4
+
+[*.cs]
 
 # CA1810: Initialize reference type static fields inline
 dotnet_diagnostic.CA1810.severity = none

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vs
+/LibgenDesktop.Setup/obj
+/LibgenDesktop/bin
+/LibgenDesktop/obj
+/packages

--- a/LibgenDesktop/Common/Constants.cs
+++ b/LibgenDesktop/Common/Constants.cs
@@ -27,6 +27,7 @@ namespace LibgenDesktop.Common
         public const int NON_FICTION_GRID_AUTHORS_COLUMN_MIN_WIDTH = 150;
         public const int NON_FICTION_GRID_SERIES_COLUMN_MIN_WIDTH = 150;
         public const int NON_FICTION_GRID_YEAR_COLUMN_MIN_WIDTH = 60;
+        public const int NON_FICTION_GRID_IDENTIFIER_COLUMN_MIN_WIDTH = 150;
         public const int NON_FICTION_GRID_LANGUAGE_COLUMN_MIN_WIDTH = 150;
         public const int NON_FICTION_GRID_PUBLISHER_COLUMN_MIN_WIDTH = 150;
         public const int NON_FICTION_GRID_FORMAT_COLUMN_MIN_WIDTH = 80;
@@ -95,6 +96,7 @@ namespace LibgenDesktop.Common
         public const int DEFAULT_NON_FICTION_GRID_AUTHORS_COLUMN_WIDTH = 200;
         public const int DEFAULT_NON_FICTION_GRID_SERIES_COLUMN_WIDTH = 180;
         public const int DEFAULT_NON_FICTION_GRID_YEAR_COLUMN_WIDTH = 60;
+        public const int DEFAULT_NON_FICTION_GRID_IDENTIFIER_COLUMN_WIDTH = 180;
         public const int DEFAULT_NON_FICTION_GRID_LANGUAGE_COLUMN_WIDTH = 180;
         public const int DEFAULT_NON_FICTION_GRID_PUBLISHER_COLUMN_WIDTH = 180;
         public const int DEFAULT_NON_FICTION_GRID_FORMAT_COLUMN_WIDTH = 100;

--- a/LibgenDesktop/Models/Localization/Localizators/SearchResultGrids/NonFictionSearchResultsGridColumnsLocalizator.cs
+++ b/LibgenDesktop/Models/Localization/Localizators/SearchResultGrids/NonFictionSearchResultsGridColumnsLocalizator.cs
@@ -11,6 +11,7 @@ namespace LibgenDesktop.Models.Localization.Localizators.SearchResultGrids
             Authors = Format(section => section?.Authors);
             Series = Format(section => section?.Series);
             Year = Format(section => section?.Year);
+            Identifier = Format(section => section?.Identifier);
             Language = Format(section => section?.Language);
             Publisher = Format(section => section?.Publisher);
             FormatColumn = Format(section => section?.Format);
@@ -23,6 +24,7 @@ namespace LibgenDesktop.Models.Localization.Localizators.SearchResultGrids
         public string Authors { get; }
         public string Series { get; }
         public string Year { get; }
+        public string Identifier { get; }
         public string Language { get; }
         public string Publisher { get; }
         public string FormatColumn { get; }

--- a/LibgenDesktop/Models/Localization/Translation.cs
+++ b/LibgenDesktop/Models/Localization/Translation.cs
@@ -275,6 +275,7 @@
             public string Authors { get; set; }
             public string Series { get; set; }
             public string Year { get; set; }
+            public string Identifier { get; set; }
             public string Language { get; set; }
             public string Publisher { get; set; }
             public string Format { get; set; }

--- a/LibgenDesktop/Models/Settings/AppSettings.cs
+++ b/LibgenDesktop/Models/Settings/AppSettings.cs
@@ -100,6 +100,7 @@ namespace LibgenDesktop.Models.Settings
                         AuthorsColumnWidth = DEFAULT_NON_FICTION_GRID_AUTHORS_COLUMN_WIDTH,
                         SeriesColumnWidth = DEFAULT_NON_FICTION_GRID_SERIES_COLUMN_WIDTH,
                         YearColumnWidth = DEFAULT_NON_FICTION_GRID_YEAR_COLUMN_WIDTH,
+                        IdentifierColumnWidth = DEFAULT_NON_FICTION_GRID_IDENTIFIER_COLUMN_WIDTH,
                         LanguageColumnWidth = DEFAULT_NON_FICTION_GRID_LANGUAGE_COLUMN_WIDTH,
                         PublisherColumnWidth = DEFAULT_NON_FICTION_GRID_PUBLISHER_COLUMN_WIDTH,
                         FormatColumnWidth = DEFAULT_NON_FICTION_GRID_FORMAT_COLUMN_WIDTH,
@@ -114,6 +115,7 @@ namespace LibgenDesktop.Models.Settings
             public int AuthorsColumnWidth { get; set; }
             public int SeriesColumnWidth { get; set; }
             public int YearColumnWidth { get; set; }
+            public int IdentifierColumnWidth { get; set; }
             public int LanguageColumnWidth { get; set; }
             public int PublisherColumnWidth { get; set; }
             public int FormatColumnWidth { get; set; }

--- a/LibgenDesktop/Resources/Languages/English.lng
+++ b/LibgenDesktop/Resources/Languages/English.lng
@@ -241,6 +241,7 @@
             "Authors": "Authors",
             "Series": "Series",
             "Year": "Year",
+            "Identifier": "Identifier",
             "Language": "Language",
             "Publisher": "Publisher",
             "Format": "Format",

--- a/LibgenDesktop/Styles/Tabs/NonFictionSearchResults.xaml
+++ b/LibgenDesktop/Styles/Tabs/NonFictionSearchResults.xaml
@@ -14,6 +14,8 @@
     <Style x:Key="YearColumnStyle" TargetType="TextBlock" BasedOn="{StaticResource SearchResultsDataGridTextColumnElementStyle}">
         <Setter Property="HorizontalAlignment" Value="Center" />
     </Style>
+    <Style x:Key="IdentifierHeaderStyle" TargetType="DataGridColumnHeader" BasedOn="{StaticResource SearchResultsDataGridLeftAlignedTextHeaderStyle}" />
+    <Style x:Key="IdentifierColumnStyle" TargetType="TextBlock" BasedOn="{StaticResource SearchResultsDataGridTextColumnElementStyle}" />
     <Style x:Key="LanguageHeaderStyle" TargetType="DataGridColumnHeader" BasedOn="{StaticResource SearchResultsDataGridLeftAlignedTextHeaderStyle}" />
     <Style x:Key="LanguageColumnStyle" TargetType="TextBlock" BasedOn="{StaticResource SearchResultsDataGridTextColumnElementStyle}" />
     <Style x:Key="PublisherHeaderStyle" TargetType="DataGridColumnHeader" BasedOn="{StaticResource SearchResultsDataGridLeftAlignedTextHeaderStyle}" />

--- a/LibgenDesktop/ViewModels/SearchResultItems/NonFictionSearchResultItemViewModel.cs
+++ b/LibgenDesktop/ViewModels/SearchResultItems/NonFictionSearchResultItemViewModel.cs
@@ -1,14 +1,50 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using LibgenDesktop.Models.Entities;
 using LibgenDesktop.Models.Localization;
 
 namespace LibgenDesktop.ViewModels.SearchResultItems
 {
+    internal class GroupingByIdentifier
+    {
+        protected Dictionary<string, int> mapUnqiqueID = new Dictionary<string, int>();
+        protected int lastId = 1;
+
+        public int GetId(NonFictionBook book)
+        {
+            if (string.IsNullOrEmpty(book.IdentifierPlain?.Trim()))
+                return 0;
+
+            string[] ids = book.IdentifierPlain.Split(',');
+            int resId = lastId;
+            foreach (var id in ids)
+            {
+                string id1 = id.Trim();
+                int uniqueId;
+                if (mapUnqiqueID.TryGetValue(id1, out uniqueId))
+                {
+                    resId = uniqueId;
+                    break;
+                }
+            }
+            if (resId == lastId)
+                ++lastId;
+            foreach (var id in ids)
+            {
+                string id1 = id.Trim();
+                if (!mapUnqiqueID.ContainsKey(id1))
+                    mapUnqiqueID[id1] = resId;
+            }
+            return resId;
+        }
+    }
+
     internal class NonFictionSearchResultItemViewModel : SearchResultItemViewModel<NonFictionBook>
     {
-        public NonFictionSearchResultItemViewModel(NonFictionBook book, LanguageFormatter formatter)
+        public NonFictionSearchResultItemViewModel(NonFictionBook book, LanguageFormatter formatter, GroupingByIdentifier grouping)
             : base(book, formatter)
         {
+            GroupId = grouping.GetId(book);
         }
 
         public NonFictionBook Book => LibgenObject;
@@ -16,6 +52,8 @@ namespace LibgenDesktop.ViewModels.SearchResultItems
         public string Authors => Book.Authors;
         public string Series => Book.Series;
         public string Year => Book.Year;
+        public string Identifier => Book.Identifier;
+        public int GroupId { get; set; }
         public string Language => Book.Language;
         public string Publisher => Book.Publisher;
         public string Format => Book.Format;

--- a/LibgenDesktop/ViewModels/Tabs/NonFictionSearchResultsTabViewModel.cs
+++ b/LibgenDesktop/ViewModels/Tabs/NonFictionSearchResultsTabViewModel.cs
@@ -30,10 +30,11 @@ namespace LibgenDesktop.ViewModels.Tabs
             List<NonFictionBook> searchResults)
             : base(mainModel, parentWindowContext, LibgenObjectType.NON_FICTION_BOOK, searchQuery)
         {
+            GroupingByIdentifier grouping = new GroupingByIdentifier();
             columnSettings = mainModel.AppSettings.NonFiction.Columns;
             LanguageFormatter formatter = MainModel.Localization.CurrentLanguage.Formatter;
             books = new ObservableCollection<NonFictionSearchResultItemViewModel>(searchResults.Select(book =>
-                new NonFictionSearchResultItemViewModel(book, formatter)));
+                new NonFictionSearchResultItemViewModel(book, formatter, grouping)));
             Initialize();
         }
 
@@ -108,6 +109,18 @@ namespace LibgenDesktop.ViewModels.Tabs
             set
             {
                 columnSettings.YearColumnWidth = value;
+            }
+        }
+
+        public int IdentifierColumnWidth
+        {
+            get
+            {
+                return columnSettings.IdentifierColumnWidth;
+            }
+            set
+            {
+                columnSettings.IdentifierColumnWidth = value;
             }
         }
 
@@ -232,8 +245,9 @@ namespace LibgenDesktop.ViewModels.Tabs
                 ShowErrorWindow(exception, ParentWindowContext);
             }
             LanguageFormatter formatter = MainModel.Localization.CurrentLanguage.Formatter;
+            GroupingByIdentifier grouping = new GroupingByIdentifier();
             Books = new ObservableCollection<NonFictionSearchResultItemViewModel>(result.Select(book =>
-                new NonFictionSearchResultItemViewModel(book, formatter)));
+                new NonFictionSearchResultItemViewModel(book, formatter, grouping)));
             UpdateBookCount();
             IsSearchResultsGridVisible = true;
             IsStatusBarVisible = true;

--- a/LibgenDesktop/Views/Tabs/NonFictionSearchResultsTab.xaml
+++ b/LibgenDesktop/Views/Tabs/NonFictionSearchResultsTab.xaml
@@ -15,6 +15,13 @@
             <RowDefinition />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <Grid.Resources>
+            <CollectionViewSource x:Key="cvsBooks" Source="{Binding Books}">
+                <CollectionViewSource.GroupDescriptions>
+                    <PropertyGroupDescription PropertyName="GroupId"/>
+                </CollectionViewSource.GroupDescriptions>
+            </CollectionViewSource>
+        </Grid.Resources>
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
@@ -56,7 +63,7 @@
                     ToolTip="{Binding Localization.ExportButtonTooltip}"
                     IsEnabled="{Binding IsExportPanelVisible, Converter={StaticResource booleanInverseConverter}}" />
         </Grid>
-        <c:BookDataGrid x:Name="bookGrid" Grid.Row="1" ItemsSource="{Binding Books, IsAsync=True}"
+        <c:BookDataGrid x:Name="bookGrid" Grid.Row="1" ItemsSource="{Binding Source={StaticResource cvsBooks}, IsAsync=True}"
                         SelectedRows="{Binding SelectedRows, Mode=OneWayToSource}"
                         Visibility="{Binding IsSearchResultsGridVisible, Converter={StaticResource booleanToCollapsedConverter}}"
                         Style="{StaticResource BookDataGrid}">
@@ -70,6 +77,31 @@
                     <Setter Property="ContextMenu" Value="{StaticResource dataGridRowMenu}" />
                 </Style>
             </DataGrid.RowStyle>
+            <DataGrid.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.ContainerStyle>
+                        <Style TargetType="{x:Type GroupItem}">
+                            <Setter Property="Margin" Value="0,0,0,5"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type GroupItem}">
+                                        <Expander IsExpanded="True" BorderBrush="#FF002255" BorderThickness="1,1,1,3">
+                                            <Expander.Header>
+                                                <DockPanel>
+                                                    <TextBlock FontWeight="Bold" Text="{Binding Path=Name}" Margin="5,0,0,0"/>
+                                                </DockPanel>
+                                            </Expander.Header>
+                                            <Expander.Content>
+                                                <ItemsPresenter />
+                                            </Expander.Content>
+                                        </Expander>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </GroupStyle.ContainerStyle>
+                </GroupStyle>
+            </DataGrid.GroupStyle>
             <DataGrid.InputBindings>
                 <KeyBinding Command="{Binding OpenDetailsCommand}" Key="Enter" />
             </DataGrid.InputBindings>
@@ -94,6 +126,11 @@
                                     Width="{Binding DataContext.YearColumnWidth, Source={StaticResource dataGridViewModel}, Converter={StaticResource dataGridLengthConverter}, Mode=TwoWay}"
                                     MinWidth="{Binding Source={x:Static const:Constants.NON_FICTION_GRID_YEAR_COLUMN_MIN_WIDTH}}"
                                     HeaderStyle="{StaticResource YearHeaderStyle}" ElementStyle="{StaticResource YearColumnStyle}" />
+                <DataGridTextColumn Binding="{Binding Identifier}"
+                                    Header="{Binding DataContext.Localization.Columns.Identifier, Source={StaticResource dataGridViewModel}}"
+                                    Width="{Binding DataContext.IdentifierColumnWidth, Source={StaticResource dataGridViewModel}, Converter={StaticResource dataGridLengthConverter}, Mode=TwoWay}"
+                                    MinWidth="{Binding Source={x:Static const:Constants.NON_FICTION_GRID_IDENTIFIER_COLUMN_MIN_WIDTH}}"
+                                    HeaderStyle="{StaticResource IdentifierHeaderStyle}" ElementStyle="{StaticResource IdentifierColumnStyle}" />
                 <DataGridTextColumn Binding="{Binding Language}"
                                     Header="{Binding DataContext.Localization.Columns.Language, Source={StaticResource dataGridViewModel}}"
                                     Width="{Binding DataContext.LanguageColumnWidth, Source={StaticResource dataGridViewModel}, Converter={StaticResource dataGridLengthConverter}, Mode=TwoWay}"


### PR DESCRIPTION
Changes:
1. .gitignore added (for bin, obj, .vs and packages folders).
2. .editorconfig modified to set the ident_size to 4 spaces (to force/match the indentation style used by the project).
3. Added Identifier column in the non-fiction books search result tab. It displays the Identifier property of the Book object.
4. Non-fiction books are grouped by the IdentifierPlain.

Issues:
1. Should the changes (3. & 4.) be applied to fiction books too?
2. Should the Identifier column be displayed or leave it hidden as before. Is it possible to show a context menu to select which columns to be visible?
3. Translations of "Identifier" column name in different languages. Using Google Translate?
4. Currently the "title" of the grouping is the group id. Anything better?
5. Color of the border of the group. Currently is hard-coded to BorderBrush="#FF002255". How to make it to follow the color theme?
